### PR TITLE
Update README.org

### DIFF
--- a/README.org
+++ b/README.org
@@ -26,7 +26,7 @@ you should get an error that prelude not found
 
 Set the path thus at shell (make sure the path below is correct!)
 #+BEGIN_SRC shell
-$ export PUGOFER=/home/[yourname]/gofer
+$ export PUGOFER=/home/[yourname]/gofer/pusimple.pre
 #+END_SRC
 Now gofer should run (at shell) ie
 #+BEGIN_SRC shell


### PR DESCRIPTION
The export command lacks the "pusimple.pre" file at the end of the path. I ran into it while installing the same.

CHANGE : 
#+BEGIN_SRC shell
$ export PUGOFER=/home/[yourname]/gofer

to

#+BEGIN_SRC shell
$ export PUGOFER=/home/[yourname]/gofer/pusimple.pre